### PR TITLE
Enhancement: CLI command to clear the Thaw cache

### DIFF
--- a/THIRD_PARTY_NOTICE.md
+++ b/THIRD_PARTY_NOTICE.md
@@ -86,7 +86,16 @@ You're able to obtain a copy of the license from https://github.com/michel-kraem
 
 ## Apache Commons IO
 
-This [library](https://github.com/apache/commons-io) is Licensed under the
-Apache License, Version 2.0 (the "License").you may not use this file except in
-compliance with the License. You may obtain a copy of the License at
+This [library](https://github.com/apache/commons-io) is licensed under the
+Apache License, Version 2.0 (the "License"). You may not use this file except in
+compliance with the license. You may obtain a copy of it at
 [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0).
+
+Additionally the attribution notices of Apache Commons IO are included:
+```
+Apache Commons IO
+Copyright 2002-2020 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (https://www.apache.org/).
+```

--- a/THIRD_PARTY_NOTICE.md
+++ b/THIRD_PARTY_NOTICE.md
@@ -83,3 +83,10 @@ It is distributed under the Apache-2.0 License which can be obtained from https:
 
 citeproc-java is used (https://github.com/michel-kraemer/citeproc-java) which is distributed unter the Apache-2.0 License.
 You're able to obtain a copy of the license from https://github.com/michel-kraemer/citeproc-java/blob/master/LICENSE.txt or http://www.apache.org/licenses/LICENSE-2.0.
+
+## Apache Commons IO
+
+This [library](https://github.com/apache/commons-io) is Licensed under the
+Apache License, Version 2.0 (the "License").you may not use this file except in
+compliance with the License. You may obtain a copy of the License at
+[http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0).

--- a/cli/src/main/java/de/be/thaw/cli/CLI.java
+++ b/cli/src/main/java/de/be/thaw/cli/CLI.java
@@ -19,6 +19,7 @@ import de.be.thaw.style.parser.exception.StyleModelParseException;
 import de.be.thaw.text.model.TextModel;
 import de.be.thaw.text.parser.TextParser;
 import de.be.thaw.text.parser.exception.ParseException;
+import de.be.thaw.util.cache.CacheUtil;
 import picocli.CommandLine;
 
 import java.io.BufferedReader;
@@ -29,6 +30,7 @@ import java.nio.charset.Charset;
 import java.nio.file.Path;
 import java.util.Locale;
 import java.util.concurrent.Callable;
+import java.io.IOException;
 
 /**
  * CLI entry point for Thaw.
@@ -59,6 +61,21 @@ public class CLI implements Callable<Integer> {
     @CommandLine.Option(names = {"-c", "--charset"}, description = "Name of the charset the files to process are encoded in. " +
             "If not specified the systems default charset will be used.")
     private String charsetName;
+
+    /**
+     * Subcommand to clean the cache folder
+     */
+    @CommandLine.Command(name="clean", description="Empty the root cache folder.")
+    int clean(){
+        try{
+            CacheUtil.cleanCacheRootDir();
+        }
+        catch(IOException e){
+            System.err.println("An exception has occurred. Root cache clean is not successful. Try again later.");
+            return ErrorResult.ROOT_CACHE_CLEANING_ERROR.getCode();
+        }
+        return ErrorResult.OK.getCode();
+    }
 
     /**
      * Entry point of the CLI application.

--- a/cli/src/main/java/de/be/thaw/cli/ErrorResult.java
+++ b/cli/src/main/java/de/be/thaw/cli/ErrorResult.java
@@ -15,7 +15,8 @@ public enum ErrorResult {
     MORE_THAN_ONE_STYLE_FILE(7),
     STYLE_FILE_PARSING_ERROR(8),
     MORE_THAN_ONE_SOURCE_FILE(9),
-    SOURCE_FILE_PARSING_ERROR(10);
+    SOURCE_FILE_PARSING_ERROR(10),
+    ROOT_CACHE_CLEANING_ERROR(11);
 
     /**
      * Code of the error.

--- a/util/build.gradle
+++ b/util/build.gradle
@@ -1,3 +1,4 @@
 dependencies {
     // Additional dependencies go here
+    compile 'commons-io:commons-io:2.8.0'
 }

--- a/util/src/main/java/de/be/thaw/util/cache/CacheUtil.java
+++ b/util/src/main/java/de/be/thaw/util/cache/CacheUtil.java
@@ -1,6 +1,7 @@
 package de.be.thaw.util.cache;
 
 import de.be.thaw.util.cache.exception.CouldNotGetProjectCacheDirectoryException;
+import org.apache.commons.io.FileUtils;
 
 import java.io.ByteArrayInputStream;
 import java.io.File;
@@ -36,6 +37,22 @@ public class CacheUtil {
         }
 
         return dir;
+    }
+
+    /**
+     * Clean the root caching directory.
+     * Tries 3 times in case of IOException.
+     *
+     * @throws IOException  in case directory access failed or other errors related to IO
+     */
+    public static void cleanCacheRootDir() throws IOException {
+        try{
+            FileUtils.cleanDirectory(getCacheRootDir());
+        }
+        catch(IOException e){
+            throw e;
+        }
+        System.out.println("Root cache cleaned successfully");
     }
 
     /**

--- a/util/src/main/java/module-info.java
+++ b/util/src/main/java/module-info.java
@@ -1,4 +1,5 @@
 module de.be.thaw.util {
+    requires org.apache.commons.io;
     exports de.be.thaw.util;
     exports de.be.thaw.util.os.exception;
     exports de.be.thaw.util.os;


### PR DESCRIPTION
Fixes #62 . 
A new sub-command `clean` has been added. Running `thaw clean` will empty the root cache folder.

I have used [apache commons io](https://github.com/apache/commons-io). Let me know if that is alright. Also, let me know if the handling of IOException is okay or you want me to change something. 

I have also updated the THIRD_PARTY_NOTICE.md file to include apache commons io license. 